### PR TITLE
add python script to modify nova.conf

### DIFF
--- a/auto-IdP/modify_novaconf.py
+++ b/auto-IdP/modify_novaconf.py
@@ -1,0 +1,23 @@
+import sys, fileinput, re
+
+def modify_novaconf():  
+    keystone_section = "[keystone_authtoken]"
+    cinder_section = "[cinder]"
+    search_text = "auth_uri"
+    repl_text = ""
+    found_keystone = False
+    fh=fileinput.input('/etc/nova/nova.conf',inplace=True)  
+    for line in fh:  
+        if keystone_section in line:
+            found_keystone = True
+
+        if search_text in line and found_keystone: 
+            repl_text = line
+        
+        if repl_text != "":
+            if cinder_section in line:
+                line = line + repl_text
+        sys.stdout.write(line) 
+    fh.close()  
+
+modify_novaconf()


### PR DESCRIPTION
So the Mix and Match for volume-attach after establishing K2K federation is never automated...
These includes: 
changes from CCI-MOC/nova (Kristi has shell script written for this)
changes from CCI-MOC/python-novaclient (Kristi has shell script written for this)
changes to nova.conf file under /etc/nova (this pull request)
- for Mix and Match use case volume-attach over k2k
- modification is made on IdP so belongs to auto-IDP/
- changes the nova.conf file under /etc/nova
